### PR TITLE
extend P2 tests

### DIFF
--- a/tests/test_p2.py
+++ b/tests/test_p2.py
@@ -1,39 +1,113 @@
 import matplotlib.pyplot as plt
 import networkx as nx
 import pytest
+from visualization import draw_graph
 
 from productions import P2
 
-
-def test_p2_should_be_applied():
+@pytest.fixture
+def initial_full_graph():
     G = nx.Graph()
     G.add_node(1, label='el', pos=(1/2, 1/2), layer=0)
     G.add_node(2, label='I', pos=(1/2, 1/2), layer=1)
     G.add_node(3, label='E', pos=(0, 0), layer=1)
     G.add_node(4, label='E', pos=(1, 0), layer=1)
-    G.add_node(5, label='E', pos=(0, 1), layer=1)
-    G.add_node(6, label='E', pos=(1, 1), layer=1)
+    G.add_node(5, label='E', pos=(1, 1), layer=1)
+    G.add_node(6, label='E', pos=(0, 1), layer=1)
     G.add_edges_from([(2, i) for i in (1, 3, 4, 5, 6)])
     G.add_edges_from([(i, i+1) for i in range(3, 6)])
     G.add_edge(3, 6)
 
+    return G
+
+def test_p2_should_be_applied_full_proper_graph(initial_full_graph):
+    G = initial_full_graph
+
     assert True == P2.apply(G)
 
-    assert [(1, {'label': 'el', 'pos': (0.5, 0.5), 'layer': 0}),
-            (2, {'label': 'i', 'pos': (0.5, 0.5), 'layer': 1}),
-            (3, {'label': 'E', 'pos': (0, 0), 'layer': 1}),
-            (4, {'label': 'E', 'pos': (1, 0), 'layer': 1}),
-            (5, {'label': 'E', 'pos': (0, 1), 'layer': 1}),
-            (6, {'label': 'E', 'pos': (1, 1), 'layer': 1}),
-            (7, {'label': 'I', 'pos': (0.25, 0.5), 'layer': 2}),
-            (8, {'label': 'I', 'pos': (0.75, 0.5), 'layer': 2}),
-            (9, {'label': 'E', 'pos': (0, 0), 'layer': 2}),
-            (10, {'label': 'E', 'pos': (0.5, 0.0), 'layer': 2}),
-            (11, {'label': 'E', 'pos': (1, 0), 'layer': 2}),
-            (12, {'label': 'E', 'pos': (0, 1), 'layer': 2}),
-            (13, {'label': 'E', 'pos': (0.5, 1.0), 'layer': 2}),
-            (14, {'label': 'E', 'pos': (1, 1), 'layer': 2})] == list(G.nodes(data=True))
+    assert [
+     (1, {'label': 'el', 'pos': (0.5, 0.5), 'layer': 0}),
+     (2, {'label': 'i', 'pos': (0.5, 0.5), 'layer': 1}),
+     (3, {'label': 'E', 'pos': (0, 0), 'layer': 1}),
+     (4, {'label': 'E', 'pos': (1, 0), 'layer': 1}),
+     (5, {'label': 'E', 'pos': (1, 1), 'layer': 1}),
+     (6, {'label': 'E', 'pos': (0, 1), 'layer': 1}), 
+     (7, {'label': 'I', 'pos': (0.25, 0.5), 'layer': 2}), 
+     (8, {'label': 'I', 'pos': (0.75, 0.5), 'layer': 2}), 
+     (9, {'label': 'E', 'pos': (0, 0), 'layer': 2}), 
+     (10, {'label': 'E', 'pos': (0.5, 0.0), 'layer': 2}), 
+     (11, {'label': 'E', 'pos': (1, 0), 'layer': 2}), 
+     (12, {'label': 'E', 'pos': (0, 1), 'layer': 2}), 
+     (13, {'label': 'E', 'pos': (0.5, 1.0), 'layer': 2}), 
+     (14, {'label': 'E', 'pos': (1, 1), 'layer': 2})] == list(G.nodes(data=True))
 
-    assert {(1, 2), (2, 3), (2, 4), (2, 5), (2, 6), (2, 8), (2, 7), (3, 4), (3, 6), (4, 5),
-            (5, 6), (7, 9), (7, 10), (7, 12), (7, 13), (8, 10), (8, 11), (8, 13), (8, 14),
-            (9, 10), (9, 12), (10, 11), (10, 13), (11, 14), (12, 13), (13, 14)} == set(G.edges)
+    assert {
+    (3, 4), (12, 13), (2, 5), (11, 14), (2, 8), (13, 14), (7, 10), (7, 13), (4, 5), 
+    (5, 6), (3, 6), (8, 11), (9, 10), (2, 4), (1, 2), (8, 14), (10, 11), (2, 7), 
+    (7, 9), (7, 12), (9, 12), (8, 10), (10, 13), (2, 3), (8, 13), (2, 6)} == set(G.edges)
+
+
+def test_p2_should_be_applied_without_edge_to_initial_node(initial_full_graph):
+    G = initial_full_graph
+    
+    G.remove_edge(1, 2)
+
+    assert True == P2.apply(G)
+
+
+def test_p2_should_be_applied_with_wrong_label_in_initial_node(initial_full_graph):
+    G = initial_full_graph
+    
+    G.nodes[1]['label'] = 'WRONG LABEL'
+
+    assert True == P2.apply(G)
+
+def test_p2_should_not_be_applied_because_of_missing_outer_edge(initial_full_graph):
+    G = initial_full_graph
+    
+    G.remove_edge(5, 6)
+
+    assert False == P2.apply(G)
+
+def test_p2_should_not_be_applied_because_of_inner_edge(initial_full_graph):
+    G = initial_full_graph
+    
+    G.remove_edge(2, 6)
+
+    assert False == P2.apply(G)
+
+def test_p2_should_not_be_applied_because_of_wrong_outer_label(initial_full_graph):
+    G = initial_full_graph
+    
+    G.nodes[6]['label'] = 'WRONG LABEL'
+
+    assert False == P2.apply(G)
+
+def test_p2_should_not_be_applied_because_of_wrong_inner_label(initial_full_graph):
+    G = initial_full_graph
+    
+    G.nodes[2]['label'] = 'WRONG LABEL'
+
+    assert False == P2.apply(G)
+
+
+def test_p2_should_not_be_applied_because_of_surplus_node(initial_full_graph):
+    G = initial_full_graph
+
+    G.remove_edge(4, 5)
+    G.add_node(7, label='E', pos=(2, 1), layer=1)
+    G.add_edge(4, 7)
+    G.add_edge(5, 7)
+
+    assert False == P2.apply(G)
+
+def test_p2_should_not_be_applied_because_of_empty_graph():
+    G = nx.Graph()
+
+    assert False == P2.apply(G)
+
+def test_p2_should_not_be_applied_because_of_initial_node_only():
+    G = nx.Graph()
+    G.add_node(1, label='El', pos=(1/2, 1/2), layer=0)
+
+    assert False == P2.apply(G)

--- a/tests/test_p2.py
+++ b/tests/test_p2.py
@@ -5,7 +5,7 @@ import pytest
 from productions import P2
 
 @pytest.fixture
-def initial_full_graph():
+def G():
     G = nx.Graph()
     G.add_node(1, label='el', pos=(1/2, 1/2), layer=0)
     G.add_node(2, label='I', pos=(1/2, 1/2), layer=1)
@@ -19,9 +19,7 @@ def initial_full_graph():
 
     return G
 
-def test_p2_should_be_applied_full_proper_graph(initial_full_graph):
-    G = initial_full_graph
-
+def test_p2_should_be_applied_full_proper_graph(G):
     assert True == P2.apply(G)
 
     assert [
@@ -46,53 +44,39 @@ def test_p2_should_be_applied_full_proper_graph(initial_full_graph):
     (7, 9), (7, 12), (9, 12), (8, 10), (10, 13), (2, 3), (8, 13), (2, 6)} == set(G.edges)
 
 
-def test_p2_should_be_applied_without_edge_to_initial_node(initial_full_graph):
-    G = initial_full_graph
-    
+def test_p2_should_be_applied_without_edge_to_initial_node(G):
     G.remove_edge(1, 2)
 
     assert True == P2.apply(G)
 
 
-def test_p2_should_be_applied_with_wrong_label_in_initial_node(initial_full_graph):
-    G = initial_full_graph
-    
+def test_p2_should_be_applied_with_wrong_label_in_initial_node(G):
     G.nodes[1]['label'] = 'WRONG LABEL'
 
     assert True == P2.apply(G)
 
-def test_p2_should_not_be_applied_because_of_missing_outer_edge(initial_full_graph):
-    G = initial_full_graph
-    
+def test_p2_should_not_be_applied_because_of_missing_outer_edge(G):
     G.remove_edge(5, 6)
 
     assert False == P2.apply(G)
 
-def test_p2_should_not_be_applied_because_of_missing_inner_edge(initial_full_graph):
-    G = initial_full_graph
-    
+def test_p2_should_not_be_applied_because_of_missing_inner_edge(G):
     G.remove_edge(2, 6)
 
     assert False == P2.apply(G)
 
-def test_p2_should_not_be_applied_because_of_wrong_outer_label(initial_full_graph):
-    G = initial_full_graph
-    
+def test_p2_should_not_be_applied_because_of_wrong_outer_label(G):
     G.nodes[6]['label'] = 'WRONG LABEL'
 
     assert False == P2.apply(G)
 
-def test_p2_should_not_be_applied_because_of_wrong_inner_label(initial_full_graph):
-    G = initial_full_graph
-    
+def test_p2_should_not_be_applied_because_of_wrong_inner_label(G):
     G.nodes[2]['label'] = 'WRONG LABEL'
 
     assert False == P2.apply(G)
 
 
-def test_p2_should_not_be_applied_because_of_surplus_node(initial_full_graph):
-    G = initial_full_graph
-
+def test_p2_should_not_be_applied_because_of_surplus_node(G):
     G.remove_edge(4, 5)
     G.add_node(7, label='E', pos=(2, 1), layer=1)
     G.add_edge(4, 7)

--- a/tests/test_p2.py
+++ b/tests/test_p2.py
@@ -1,7 +1,6 @@
 import matplotlib.pyplot as plt
 import networkx as nx
 import pytest
-from visualization import draw_graph
 
 from productions import P2
 

--- a/tests/test_p2.py
+++ b/tests/test_p2.py
@@ -69,7 +69,7 @@ def test_p2_should_not_be_applied_because_of_missing_outer_edge(initial_full_gra
 
     assert False == P2.apply(G)
 
-def test_p2_should_not_be_applied_because_of_inner_edge(initial_full_graph):
+def test_p2_should_not_be_applied_because_of_missing_inner_edge(initial_full_graph):
     G = initial_full_graph
     
     G.remove_edge(2, 6)


### PR DESCRIPTION
closes #15 
created fixture:
![image](https://user-images.githubusercontent.com/44035398/207947936-93aabd68-101d-497e-8285-7ddb29d58712.png)
added tests:
- full graph without initial edge 
![image](https://user-images.githubusercontent.com/44035398/207948247-3bec47e0-fa3d-4088-94ad-eb3210dbbdae.png)
- full graph with wrong label in initial node 
![image](https://user-images.githubusercontent.com/44035398/207948400-264dea9c-391d-4e49-9850-20dd0fbd2bd7.png)
- full graph with missing outer edge: 
![image](https://user-images.githubusercontent.com/44035398/207948515-185d651b-c97a-4a58-8200-e30364826d1f.png)
- full graph with mising inner edge: 
![image](https://user-images.githubusercontent.com/44035398/207948570-346dcca3-6d49-41c4-9025-dfcfda03bd8e.png)
- full graph with wrong outer label: 
![image](https://user-images.githubusercontent.com/44035398/207948661-d3087281-4b61-4fa7-8207-262af9c22963.png)
- full graph with wrong inner label:  
![image](https://user-images.githubusercontent.com/44035398/207948759-532dd660-edc6-46a8-b43b-7bc4239887ee.png)
- full graph with surplus node :
![image](https://user-images.githubusercontent.com/44035398/207948846-d6c56cf4-736d-4a9d-8999-4317d66442be.png)
- empthy graph
- initial node only graph